### PR TITLE
Path: Fixes for PathPost and jtech post-processor

### DIFF
--- a/src/Mod/Path/PathScripts/PathPost.py
+++ b/src/Mod/Path/PathScripts/PathPost.py
@@ -242,10 +242,12 @@ class CommandPathPost:
                 job = None
         if job is None:
             targetlist = []
+            jobNames = []
             for o in FreeCAD.ActiveDocument.Objects:
                 if hasattr(o, "Proxy"):
                     if isinstance(o.Proxy, PathJob.ObjectJob):
                         targetlist.append(o.Label)
+                        jobNames.append(o.Name)
             PathLog.debug("Possible post objects: {}".format(targetlist))
             if len(targetlist) > 1:
                 form = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobChooser.ui")
@@ -254,9 +256,11 @@ class CommandPathPost:
                 if r is False:
                     return
                 else:
-                    jobname = form.cboProject.currentText()
+                    jobLabel = form.cboProject.currentText()
+                    nameIdx = targetlist.index(jobLabel)
+                    jobname = jobNames[nameIdx]
             else:
-                jobname = targetlist[0]
+                jobname = jobNames[0]
             job = FreeCAD.ActiveDocument.getObject(jobname)
 
         PathLog.debug("about to postprocess job: {}".format(job.Name))

--- a/src/Mod/Path/PathScripts/post/jtech_post.py
+++ b/src/Mod/Path/PathScripts/post/jtech_post.py
@@ -106,8 +106,8 @@ TOOL_CHANGE = ''''''
 POWER_ON_DELAY = 0
 
 # to distinguish python built-in open function from the one declared below
-if open.__module__ == '__builtin__':
-    pythonopen = open
+if open.__module__ in ['__builtin__', 'io']:
+  pythonopen = open
 
 
 def processArguments(argstring):
@@ -220,7 +220,7 @@ def export(objectslist, filename, argstring):
     print("done postprocessing.")
 
     if not filename == '-':
-        gfile = pythonopen(filename, "wb")
+        gfile = pythonopen(filename, "w")
         gfile.write(final)
         gfile.close()
 


### PR DESCRIPTION
Fixes a `job.Label` bug that should be a `job.Name` reference in PathPost.
Fixes `pythonopen` definition and usage in jtech postprocessor.