### PR TITLE
rename SafeHeight to RapidHeight (instead of OpRapidsHeight)

### DIFF
--- a/src/Mod/CAM/Roadmap/ADR/ADR-003.md
+++ b/src/Mod/CAM/Roadmap/ADR/ADR-003.md
@@ -13,11 +13,11 @@ The operation is responsible for acting on all of the target geometry selected. 
 faces to be cleared.  It is the responsibility of the operation to move the cutter into each area, clear it, retract and move to the next.
 
 - Clearance Height shall be assumed to be safe to move laterally at any time with the loaded tool.
-- Ambiguous term "Safe height" (safe for what?) shall be renamed OpRapidsHeight to indicate its function.
-- OpRapidsHeight shall be assumed to be safe for lateral G0 moves between different cuts within the same operation.
+- Ambiguous term "Safe height" (safe for what?) shall be renamed RapidHeight to indicate its function.
+- RapidHeight shall be assumed to be safe for lateral G0 moves between different cuts within the same operation.
 - It is the users responsability to select a suitable value. FreeCAD does not do collision checks on the 3D model.
 - The operation shall rapid (G0) the cutter to Clearance Height at the start of the operation.
-- Before acting on any target geometry, the cutter should move at rapid speed to OpRapidsHeight.
+- Before acting on any target geometry, the cutter should move at rapid speed to RapidHeight.
 - The operation shall end with a G0 <clearance height> to restore the cutter to  clearance in preparation for the next operation.
 
 
@@ -28,5 +28,5 @@ Advantages
 
 Disadvantages
 - Moves to clearance height between operations may not be as efficient as possible.
-- Since this is two rapids between OpRapidsHeight and OpRapidsHeight, machine time penalty is minimal.
+- Since this is two rapids between RapidHeight and RapidHeight, machine time penalty is minimal.
 - Final refinement should be left to the postprocessor.


### PR DESCRIPTION
Trying out this PR to sliptonics roadmap branch idea.

Here is a PR implementing the change I proposed in https://github.com/FreeCAD/FreeCAD/discussions/22536#discussioncomment-13841930